### PR TITLE
Replace plasma-wayland-session with plasma-workspace

### DIFF
--- a/plasma.yaml
+++ b/plasma.yaml
@@ -6,7 +6,7 @@ packages:
   - 'kde-system-meta'
   - 'kde-utilities-meta'
   - 'plasma'
-  - 'plasma-wayland-session'
+  - 'plasma-workspace'
   - 'sddm'
   - 'waydroid'
   - 'waydroid-image'


### PR DESCRIPTION
Since KDE 6 launched, the track change to Plasma now fails because the package plasma-wayland-session has been replaced with plasma-workspace. I tried testing the change and I am getting a black screen but I am not sure if it is just this i3-4005U laptop being incapable of running a VM properly or if there is some issue with the fix.