### PR TITLE
Don't show gnome-initial-setup in users list when switching to plasma

### DIFF
--- a/plasma.yaml
+++ b/plasma.yaml
@@ -16,3 +16,7 @@ services:
 
 commands:
   - 'rm -f /usr/share/applications/Waydroid.desktop'
+  - 'cat << EOF > /usr/lib/sddm/sddm.conf.d/no-gnome-initial-setup.conf
+[Users]
+HideUsers=gnome-initial-setup
+EOF'


### PR DESCRIPTION
This pull request should fix the display of the gnome-initial-setup user after switching from the default-gnome track to the plasma track.