### PR TITLE
Add Cosmic Track to BlendOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 * LXQT: `lxqt`
 * MATE: `mate`
 * XFCE: `xfce`
+* Cosmice-DE: `cosmic`
 
 ## Example GNOME `/system.yaml` (vanilla)
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 * LXQT: `lxqt`
 * MATE: `mate`
 * XFCE: `xfce`
-* Cosmice-DE: `cosmic`
+* Cosmic: `cosmic`
 
 ## Example GNOME `/system.yaml` (vanilla)
 

--- a/cosmic.yaml
+++ b/cosmic.yaml
@@ -8,7 +8,6 @@ packages:
   - 'cosmic-bg'
   - 'cosmic-comp'
   - 'cosmic-files'
-  - 'cosmic-greeter'
   - 'cosmic-idle'
   - 'cosmic-launcher'
   - 'cosmic-notifications'
@@ -25,6 +24,7 @@ packages:
   - 'cosmic-wallpapers'
   - 'cosmic-workspaces'
   - 'xdg-desktop-portal-cosmic'
+  - 'gdm'
 
 services:
-  - 'cosmic-greeter'
+  - 'gdm'

--- a/cosmic.yaml
+++ b/cosmic.yaml
@@ -1,0 +1,30 @@
+impl: 'https://github.com/blend-os/tracks/raw/main'
+
+track: 'blendos-base'
+
+packages:
+  - 'cosmic-app-library'
+  - 'cosmic-applets'
+  - 'cosmic-bg'
+  - 'cosmic-comp'
+  - 'cosmic-files'
+  - 'cosmic-greeter'
+  - 'cosmic-idle'
+  - 'cosmic-launcher'
+  - 'cosmic-notifications'
+  - 'cosmic-osd'
+  - 'cosmic-panel'
+  - 'cosmic-randr'
+  - 'cosmic-screenshot'
+  - 'cosmic-session'
+  - 'cosmic-settings'
+  - 'cosmic-settings-daemon'
+  - 'cosmic-store'
+  - 'cosmic-terminal'
+  - 'cosmic-text-editor'
+  - 'cosmic-wallpapers'
+  - 'cosmic-workspaces'
+  - 'xdg-desktop-portal-cosmic'
+
+services:
+  - 'cosmic-greeter'


### PR DESCRIPTION
Added a barebones track for the cosmic desktop. This track pulls in only the cosmic desktop environment and nothing else, intended for a minimal system base.

Currently, gdm is being used instead of cosmic-greeter due to a buggy implementation of it.

Also updated readme to reflect new track.